### PR TITLE
Misc code style fixes

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -81,15 +81,12 @@ namespace Power {
                 var plug_grid = create_notebook_pages (true);
                 stack.add_titled (plug_grid, "ac", _("Plugged In"));
 
-                stack_container.add (info_bars);
-
                 stack_switcher = new Gtk.StackSwitcher ();
                 stack_switcher.homogeneous = true;
                 stack_switcher.stack = stack;
 
-
                 if (battery_detect ()) {
-                    Gtk.Grid battery_grid = create_notebook_pages (false);
+                    var battery_grid = create_notebook_pages (false);
                     stack.add_titled (battery_grid, "battery", _("On Battery"));
 
                     var left_sep = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
@@ -109,9 +106,10 @@ namespace Power {
                 }
 
                 main_grid.attach (stack, 0, 8, 2, 1);
-                stack_container.add (main_grid);
 
                 stack_container.margin_bottom = 12;
+                stack_container.add (info_bars);
+                stack_container.add (main_grid);
                 stack_container.show_all ();
 
                 // hide stack switcher if we only have ac line
@@ -168,9 +166,6 @@ namespace Power {
         }
 
         private Gtk.Grid create_info_bars () {
-            var info_grid = new Gtk.Grid ();
-            info_grid.column_homogeneous = true;
-
             var infobar = new Gtk.InfoBar ();
             infobar.message_type = Gtk.MessageType.WARNING;
             infobar.no_show_all = true;
@@ -186,21 +181,21 @@ namespace Power {
 
             var label = new Gtk.Label (_("Some changes will not take effect until you restart this computer"));
 
-            var content = infobar.get_content_area () as Gtk.Container;
-            content.add (label);
+            infobar.get_content_area ().add (label);
 
             var permission_infobar = new Gtk.InfoBar ();
             permission_infobar.message_type = Gtk.MessageType.INFO;
 
             var permission = get_permission ();
 
-            var area_infobar = permission_infobar.get_action_area () as Gtk.Container;
             var lock_button = new Gtk.LockButton (permission);
+
+            var label_infobar = new Gtk.Label (_("Some settings require administrator rights to be changed"));
+
+            var area_infobar = permission_infobar.get_action_area () as Gtk.Container;
             area_infobar.add (lock_button);
 
-            var content_infobar = permission_infobar.get_content_area () as Gtk.Container;
-            var label_infobar = new Gtk.Label (_("Some settings require administrator rights to be changed"));
-            content_infobar.add (label_infobar);
+            permission_infobar.get_content_area ().add (label_infobar);
 
             if (lid_detect ()) {
                 permission_infobar.no_show_all = false;
@@ -218,6 +213,8 @@ namespace Power {
                 }
             });
 
+            var info_grid = new Gtk.Grid ();
+            info_grid.column_homogeneous = true;
             info_grid.attach (infobar, 0, 0, 1, 1);
             info_grid.attach (permission_infobar, 0, 1, 1, 1);
 
@@ -225,22 +222,14 @@ namespace Power {
         }
 
         private Gtk.Grid create_common_settings () {
-            lock_image = new Gtk.Image.from_icon_name ("changes-prevent-symbolic", Gtk.IconSize.BUTTON);
-            lock_image.tooltip_text = NO_PERMISSION_STRING;
-            lock_image.sensitive = false;
-            lock_image2 = new Gtk.Image.from_icon_name ("changes-prevent-symbolic", Gtk.IconSize.BUTTON);
-            lock_image2.tooltip_text = NO_PERMISSION_STRING;
-            lock_image2.sensitive = false;
-
             if (backlight_detect ()) {
                 var brightness_label = new Gtk.Label (_("Display brightness:"));
-                ((Gtk.Misc) brightness_label).xalign = 1.0f;
-                label_size.add_widget (brightness_label);
                 brightness_label.halign = Gtk.Align.END;
+                brightness_label.xalign = 1;
 
                 var als_label = new Gtk.Label (_("Automatically adjust brightness:"));
-                ((Gtk.Misc) als_label).xalign = 1.0f;
-                label_size.add_widget (als_label);
+                als_label.xalign = 1;
+
                 var als_switch = new Gtk.Switch ();
                 als_switch.halign = Gtk.Align.START;
 
@@ -260,6 +249,9 @@ namespace Power {
                 main_grid.attach (scale, 1, 0, 1, 1);
                 main_grid.attach (als_label, 0, 1, 1, 1);
                 main_grid.attach (als_switch, 1, 1, 1, 1);
+
+                label_size.add_widget (brightness_label);
+                label_size.add_widget (als_label);
             }
 
             if (lid_detect ()) {
@@ -272,6 +264,14 @@ namespace Power {
                 lid_dock_box.sensitive = false;
                 lid_dock_box.label.sensitive = false;
                 label_size.add_widget (lid_dock_box.label);
+
+                lock_image = new Gtk.Image.from_icon_name ("changes-prevent-symbolic", Gtk.IconSize.BUTTON);
+                lock_image.tooltip_text = NO_PERMISSION_STRING;
+                lock_image.sensitive = false;
+
+                lock_image2 = new Gtk.Image.from_icon_name ("changes-prevent-symbolic", Gtk.IconSize.BUTTON);
+                lock_image2.tooltip_text = NO_PERMISSION_STRING;
+                lock_image2.sensitive = false;
 
                 var permission = get_permission ();
 
@@ -304,19 +304,20 @@ namespace Power {
 
             var screen_timeout_label = new Gtk.Label (_("Turn off display when inactive for:"));
             screen_timeout_label.halign = Gtk.Align.END;
-            screen_timeout_label.xalign = 1.0f;
-            label_size.add_widget (screen_timeout_label);
+            screen_timeout_label.xalign = 1;
 
             var screen_timeout = new TimeoutComboBox (pantheon_dpms_settings, "standby-time");
             screen_timeout.changed.connect (run_dpms_helper);
 
             var power_combobox = new ActionComboBox (_("Power button:"), "power-button-action");
-            label_size.add_widget (power_combobox.label);
 
             main_grid.attach (screen_timeout_label, 0, 3, 1, 1);
             main_grid.attach (screen_timeout, 1, 3, 1, 1);
             main_grid.attach (power_combobox.label, 0, 4, 1, 1);
             main_grid.attach (power_combobox, 1, 4, 1, 1);
+
+            label_size.add_widget (screen_timeout_label);
+            label_size.add_widget (power_combobox.label);
 
             return main_grid;
         }
@@ -339,12 +340,8 @@ namespace Power {
         }
 
         private Gtk.Grid create_notebook_pages (bool ac) {
-            var grid = new Gtk.Grid ();
-            grid.column_spacing = 12;
-            grid.row_spacing = 12;
-
             var sleep_timeout_label = new Gtk.Label (_("Sleep when inactive for:"));
-            ((Gtk.Misc) sleep_timeout_label).xalign = 1.0f;
+            sleep_timeout_label.xalign = 1;
             label_size.add_widget (sleep_timeout_label);
 
             string type = "battery";
@@ -355,13 +352,16 @@ namespace Power {
             var scale_settings = @"sleep-inactive-%s-timeout".printf (type);
             var sleep_timeout = new TimeoutComboBox (settings, scale_settings);
 
+            var grid = new Gtk.Grid ();
+            grid.column_spacing = 12;
+            grid.row_spacing = 12;
             grid.attach (sleep_timeout_label, 0, 1, 1, 1);
             grid.attach (sleep_timeout, 1, 1, 1, 1);
 
             if (!ac && backlight_detect ()){
                 var dim_label = new Gtk.Label (_("Dim display when inactive:"));
-                ((Gtk.Misc) dim_label).xalign = 1.0f;
-                label_size.add_widget (dim_label);
+                dim_label.xalign = 1;
+
                 var dim_switch = new Gtk.Switch ();
                 dim_switch.halign = Gtk.Align.START;
 
@@ -369,7 +369,10 @@ namespace Power {
 
                 grid.attach (dim_label, 0, 0, 1, 1);
                 grid.attach (dim_switch, 1, 0, 1, 1);
+
+                label_size.add_widget (dim_label);
             }
+
             return grid;
         }
 
@@ -386,7 +389,7 @@ namespace Power {
                     return true;
                 }
 
-            enumerator.close ();
+                enumerator.close ();
 
             } catch (GLib.Error err) {
                 critical ("%s", err.message);
@@ -427,20 +430,20 @@ namespace Power {
                 FileInfo power_supply;
 
                 while ((power_supply = enumerator.next_file ()) != null) {
-                    var supply = interface_path.resolve_relative_path (
-                        power_supply.get_name ());
+                    var supply = interface_path.resolve_relative_path (power_supply.get_name ());
                     var supply_type = supply.get_child ("type");
 
-                    var dis = new DataInputStream(supply_type.read ());
+                    var dis = new DataInputStream (supply_type.read ());
                     string type;
-                    if ((type = dis.read_line(null)) == "Battery") {
+                    if ((type = dis.read_line (null)) == "Battery") {
                         debug ("Detected battery");
                         return true;
                     }
+
                     continue;
                 }
 
-            enumerator.close ();
+                enumerator.close ();
 
             } catch (GLib.Error err) {
                 critical ("%s", err.message);

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -30,8 +30,6 @@ namespace Power {
         private PowerSettings screen;
         private Battery battery;
         private PowerSupply power_supply;
-        private Gtk.Image lock_image;
-        private Gtk.Image lock_image2;
         private Gtk.Scale scale;
 
         private const string NO_PERMISSION_STRING  = _("You do not have permission to change this");
@@ -265,11 +263,11 @@ namespace Power {
                 lid_dock_box.label.sensitive = false;
                 label_size.add_widget (lid_dock_box.label);
 
-                lock_image = new Gtk.Image.from_icon_name ("changes-prevent-symbolic", Gtk.IconSize.BUTTON);
+                var lock_image = new Gtk.Image.from_icon_name ("changes-prevent-symbolic", Gtk.IconSize.BUTTON);
                 lock_image.tooltip_text = NO_PERMISSION_STRING;
                 lock_image.sensitive = false;
 
-                lock_image2 = new Gtk.Image.from_icon_name ("changes-prevent-symbolic", Gtk.IconSize.BUTTON);
+                var lock_image2 = new Gtk.Image.from_icon_name ("changes-prevent-symbolic", Gtk.IconSize.BUTTON);
                 lock_image2.tooltip_text = NO_PERMISSION_STRING;
                 lock_image2.sensitive = false;
 


### PR DESCRIPTION
* Remove unnecessary casts to `Gtk.Misc`
* use `var`
* Remove unnecessary casts to `Gtk.Container`
* Only create lock images on lid detect
* Organize, fix indentation, space around `()`