### PR TITLE
Avoid going in critical when lid interface doesn't exist

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -404,8 +404,8 @@ namespace Power {
 
             try {
                 var enumerator = interface_path.enumerate_children (
-                GLib.FileAttribute.STANDARD_NAME,
-                FileQueryInfoFlags.NONE);
+                    GLib.FileAttribute.STANDARD_NAME,
+                    FileQueryInfoFlags.NONE);
                 FileInfo backlight;
                 if ((backlight = enumerator.next_file ()) != null) {
                     debug ("Detected backlight interface");

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -378,7 +378,7 @@ namespace Power {
         private static bool lid_detect () {
             var interface_path = File.new_for_path ("/proc/acpi/button/lid/");
 
-            if (interface_path.query_exists()) {
+            if (interface_path.query_exists ()) {
                 try {
                     var enumerator = interface_path.enumerate_children (
                         GLib.FileAttribute.STANDARD_NAME,

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -384,7 +384,6 @@ namespace Power {
                         GLib.FileAttribute.STANDARD_NAME,
                         FileQueryInfoFlags.NONE);
                     FileInfo lid;
-
                     if ((lid = enumerator.next_file ()) != null) {
                         debug ("Detected lid switch");
                         return true;

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -378,20 +378,22 @@ namespace Power {
         private static bool lid_detect () {
             var interface_path = File.new_for_path ("/proc/acpi/button/lid/");
 
-            try {
-                var enumerator = interface_path.enumerate_children (
-                GLib.FileAttribute.STANDARD_NAME,
-                FileQueryInfoFlags.NONE);
-                FileInfo lid;
-                if ((lid = enumerator.next_file ()) != null) {
-                    debug ("Detected lid switch");
-                    return true;
+            if (interface_path.query_exists()) {
+                try {
+                    var enumerator = interface_path.enumerate_children (
+                    GLib.FileAttribute.STANDARD_NAME,
+                    FileQueryInfoFlags.NONE);
+                    FileInfo lid;
+                    if ((lid = enumerator.next_file ()) != null) {
+                        debug ("Detected lid switch");
+                        return true;
+                    }
+
+                    enumerator.close ();
+
+                } catch (GLib.Error err) {
+                    critical ("%s", err.message);
                 }
-
-                enumerator.close ();
-
-            } catch (GLib.Error err) {
-                critical ("%s", err.message);
             }
 
             return false;
@@ -410,7 +412,7 @@ namespace Power {
                     return true;
                 }
 
-            enumerator.close ();
+                enumerator.close ();
 
             } catch (GLib.Error err) {
                 critical ("%s", err.message);

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -381,9 +381,10 @@ namespace Power {
             if (interface_path.query_exists()) {
                 try {
                     var enumerator = interface_path.enumerate_children (
-                    GLib.FileAttribute.STANDARD_NAME,
-                    FileQueryInfoFlags.NONE);
+                        GLib.FileAttribute.STANDARD_NAME,
+                        FileQueryInfoFlags.NONE);
                     FileInfo lid;
+
                     if ((lid = enumerator.next_file ()) != null) {
                         debug ("Detected lid switch");
                         return true;


### PR DESCRIPTION
- /proc/acpi/button/lid/ could not exist on systems without LID switch (tested in VirtualBox VM)
- thus false when there is nothing to detect
- better indentation