### PR TITLE
Standardize on suspend (i18n)

### DIFF
--- a/po/aa.po
+++ b/po/aa.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ab.po
+++ b/po/ab.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ae.po
+++ b/po/ae.po
@@ -22,7 +22,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -34,7 +34,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -70,7 +70,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -106,7 +106,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/af.po
+++ b/po/af.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Krag"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr "Loop op Battery"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr "Kragknoppie"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ak.po
+++ b/po/ak.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/am.po
+++ b/po/am.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "ሐይል"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr "በ ባትሪ"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr "የ ሐይል ቁልፍ:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/an.po
+++ b/po/an.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ar.po
+++ b/po/ar.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "الطاقة"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr "زر الطاقة:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/as.po
+++ b/po/as.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ast.po
+++ b/po/ast.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/av.po
+++ b/po/av.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ay.po
+++ b/po/ay.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/az.po
+++ b/po/az.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ba.po
+++ b/po/ba.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/be.po
+++ b/po/be.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr "Сілкаванне"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr "Ад батарэі"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr "Кнопка сілкавання:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/bg.po
+++ b/po/bg.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Захранване"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Настройване на яркостта на екрана, копчетата за захранването и поведението "
 "за заспиване"
@@ -49,7 +49,7 @@ msgid "On Battery"
 msgstr "На батерия"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -85,7 +85,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -124,7 +124,7 @@ msgstr "Копче за включване:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Изключване на екрана при бездействие за:"
 
 #: src/Plug.vala:361

--- a/po/bh.po
+++ b/po/bh.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/bi.po
+++ b/po/bi.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/bm.po
+++ b/po/bm.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/bn.po
+++ b/po/bn.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "পাওয়ার"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/bo.po
+++ b/po/bo.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/br.po
+++ b/po/br.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/bs.po
+++ b/po/bs.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Napajanje"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr "Na bateriji"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr "Taster za gašenje:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/btk.po
+++ b/po/btk.po
@@ -52,7 +52,7 @@ msgid "Power"
 msgstr ""
 
 #: ../src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: ../src/Plug.vala:75
@@ -64,7 +64,7 @@ msgid "On Battery"
 msgstr ""
 
 #: ../src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: ../src/Plug.vala:144
@@ -100,7 +100,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: ../src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: ../src/Plug.vala:166
@@ -136,7 +136,7 @@ msgid "Power button:"
 msgstr ""
 
 #: ../src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: ../src/Plug.vala:361

--- a/po/ca.po
+++ b/po/ca.po
@@ -37,7 +37,7 @@ msgid "Power"
 msgstr "Energia"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Configureu la brillantor de la pantalla, els botons d'engegar i el "
 "comportament de l'aturada temporal."
@@ -51,7 +51,7 @@ msgid "On Battery"
 msgstr "Amb la bateria"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Botó d'aturada temporal"
 
 #: src/Plug.vala:144
@@ -87,7 +87,7 @@ msgid "Docked lid close"
 msgstr "Tancament de la pantalla acoblada"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Aturada temporal inactiva"
 
 #: src/Plug.vala:166
@@ -124,7 +124,7 @@ msgid "Power button:"
 msgstr "Botó d'engegada:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Atura temporalment quan estigui inactiu durant..."
 
 #: src/Plug.vala:361

--- a/po/ce.po
+++ b/po/ce.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ch.po
+++ b/po/ch.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/co.po
+++ b/po/co.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/cr.po
+++ b/po/cr.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/cs.po
+++ b/po/cs.po
@@ -36,7 +36,7 @@ msgid "Power"
 msgstr "Napájení"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Konfigurovat jas obrazovky, tlačítka napájení a funkce uspávání"
 
 #: src/Plug.vala:75
@@ -48,7 +48,7 @@ msgid "On Battery"
 msgstr "Napájení z baterie"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -84,7 +84,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -121,7 +121,7 @@ msgstr "Tlačítko napájení:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Vypnout obrazovku, když je neaktivní:"
 
 #: src/Plug.vala:361

--- a/po/cu.po
+++ b/po/cu.po
@@ -22,7 +22,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -34,7 +34,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -70,7 +70,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -106,7 +106,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/cv.po
+++ b/po/cv.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/cy.po
+++ b/po/cy.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/da.po
+++ b/po/da.po
@@ -36,7 +36,7 @@ msgid "Power"
 msgstr "Strøm"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Konfigurer skærmens lysstyrke, strømknapper og soveopførsel"
 
 #: src/Plug.vala:75
@@ -48,7 +48,7 @@ msgid "On Battery"
 msgstr "På batteri"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Soveknap"
 
 #: src/Plug.vala:144
@@ -84,7 +84,7 @@ msgid "Docked lid close"
 msgstr "Dokket låg lukket"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Sove inaktiv"
 
 #: src/Plug.vala:166
@@ -122,7 +122,7 @@ msgstr "Tænd/sluk-knap:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Sæt i hvile ved inaktivitet i:"
 
 #: src/Plug.vala:361

--- a/po/de.po
+++ b/po/de.po
@@ -38,7 +38,7 @@ msgid "Power"
 msgstr "Stromversorgung"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Bildschirmhelligkeit, Ein-/Ausschalter und Energiesparverhalten einrichten"
 
@@ -51,7 +51,7 @@ msgid "On Battery"
 msgstr "Akkubetrieb"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Bereitschaftsknopf"
 
 #: src/Plug.vala:144
@@ -87,7 +87,7 @@ msgid "Docked lid close"
 msgstr "Am Dock Deckel geschlossen"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Kein Bereitschaftsmodus"
 
 #: src/Plug.vala:166
@@ -126,7 +126,7 @@ msgstr "Ein-/Ausschalter:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "In Bereitschaft versetzen, wenn inaktiv seit:"
 
 #: src/Plug.vala:361

--- a/po/dv.po
+++ b/po/dv.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/dz.po
+++ b/po/dz.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ee.po
+++ b/po/ee.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/el.po
+++ b/po/el.po
@@ -36,7 +36,7 @@ msgid "Power"
 msgstr "Ενέργεια"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Ρύθμιση φωτεινότητας οθόνης, κουμπιών ενέργειας και συμπεριφοράς ύπνου"
 
 #: src/Plug.vala:75
@@ -48,7 +48,7 @@ msgid "On Battery"
 msgstr "Με μπαταρία"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Κουμπί ύπνου"
 
 #: src/Plug.vala:144
@@ -84,7 +84,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -123,7 +123,7 @@ msgstr "Κουμπί τροφοδοσίας:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Αναστολή όταν παραμείνει σε αδράνεια για:"
 
 #: src/Plug.vala:361

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -120,7 +120,7 @@ msgstr "Power button:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Dim display when inactive:"
 
 #: src/Plug.vala:361

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -35,8 +35,8 @@ msgid "Power"
 msgstr "Power"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
-msgstr "Configure display brightness, power buttons, and sleep behaviour"
+msgid "Configure display brightness, power buttons, and suspend behavior"
+msgstr "Configure display brightness, power buttons, and suspend behaviour"
 
 #: src/Plug.vala:75
 msgid "Plugged In"
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr "On Battery"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -120,7 +120,7 @@ msgstr "Power button:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Turn off display when inactive for:"
 
 #: src/Plug.vala:361

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Power"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr "Power button:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/eo.po
+++ b/po/eo.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/es.po
+++ b/po/es.po
@@ -38,7 +38,7 @@ msgid "Power"
 msgstr "Energía"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Configurar el brillo de pantalla, los botones de encendido y las opciones de "
 "suspensión"
@@ -52,7 +52,7 @@ msgid "On Battery"
 msgstr "Con batería"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Botón de suspensión"
 
 #: src/Plug.vala:144
@@ -88,7 +88,7 @@ msgid "Docked lid close"
 msgstr "Cierre de la tapa acoplada"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Dormir inactivo"
 
 #: src/Plug.vala:166
@@ -127,7 +127,7 @@ msgid "Power button:"
 msgstr "Botón de encendido:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Dormir cuando esté inactivo por:"
 
 #: src/Plug.vala:361

--- a/po/et.po
+++ b/po/et.po
@@ -36,7 +36,7 @@ msgid "Power"
 msgstr "Toide"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Ekraani heleduse, toite nuppude ja puhkerežiimi seadistamine"
 
 #: src/Plug.vala:75
@@ -48,7 +48,7 @@ msgid "On Battery"
 msgstr "Aku kasutamisel"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -84,7 +84,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -121,7 +121,7 @@ msgstr "Toite nupp:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Ekraani väljalülitamime, kui ollakse eemal:"
 
 #: src/Plug.vala:361

--- a/po/eu.po
+++ b/po/eu.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Energia"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr "Itzali botoia:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/fa.po
+++ b/po/fa.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "برق"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ff.po
+++ b/po/ff.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/fi.po
+++ b/po/fi.po
@@ -36,7 +36,7 @@ msgid "Power"
 msgstr "Virransäästö"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Määritä näytön kirkkaus, virtapainikkeet ja virransäästötilan toiminta"
 
 #: src/Plug.vala:75
@@ -48,7 +48,7 @@ msgid "On Battery"
 msgstr "Akkuvirralla"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Lepopainike"
 
 #: src/Plug.vala:144
@@ -84,7 +84,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -123,7 +123,7 @@ msgstr "Virtapainike:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Siirry valmiustilaan tietyn ajan jälkeen:"
 
 #: src/Plug.vala:361

--- a/po/fj.po
+++ b/po/fj.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/fo.po
+++ b/po/fo.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/fr.po
+++ b/po/fr.po
@@ -40,7 +40,7 @@ msgid "Power"
 msgstr "Alimentation"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Régler la luminosité de l'écran, le comportement du bouton d'alimentation "
 "ainsi que la mise en veille"
@@ -54,7 +54,7 @@ msgid "On Battery"
 msgstr "Sur batterie"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Boutton veille"
 
 #: src/Plug.vala:144
@@ -90,7 +90,7 @@ msgid "Docked lid close"
 msgstr "Rabat de l'écran"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Veille d'inactivité"
 
 #: src/Plug.vala:166
@@ -129,7 +129,7 @@ msgid "Power button:"
 msgstr "Bouton de mise sous tension :"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Mettre en veille si inactif depuis :"
 
 #: src/Plug.vala:361

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/fy.po
+++ b/po/fy.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ga.po
+++ b/po/ga.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/gd.po
+++ b/po/gd.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/gl.po
+++ b/po/gl.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Carga"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr "Con batería"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr "Botón de apagado"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/gn.po
+++ b/po/gn.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/gu.po
+++ b/po/gu.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/gv.po
+++ b/po/gv.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ha.po
+++ b/po/ha.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/he.po
+++ b/po/he.po
@@ -37,7 +37,7 @@ msgid "Power"
 msgstr "צריכת חשמל"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "הגדרת בהירות המסך, כפתורי הכיבוי והתנהגות מצב שינה"
 
 #: src/Plug.vala:75
@@ -49,7 +49,7 @@ msgid "On Battery"
 msgstr "על סוללה"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "כפתור שינה"
 
 #: src/Plug.vala:144
@@ -85,7 +85,7 @@ msgid "Docked lid close"
 msgstr "סגירת מכסה בתחנת עגינה"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "שינה בלתי פעילה"
 
 #: src/Plug.vala:166
@@ -121,7 +121,7 @@ msgid "Power button:"
 msgstr "כפתור הפעלה:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "יש לעבור למצב שינה בעת חוסר פעילות למשך:"
 
 #: src/Plug.vala:361

--- a/po/hi.po
+++ b/po/hi.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ho.po
+++ b/po/ho.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/hr.po
+++ b/po/hr.po
@@ -39,7 +39,7 @@ msgid "Power"
 msgstr "Energija"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Prilagodite svjetlinu zaslona, tipku isključivanja i ponašanje spavanja"
 
@@ -52,7 +52,7 @@ msgid "On Battery"
 msgstr "Na bateriji"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Tipka spavanja"
 
 #: src/Plug.vala:144
@@ -88,7 +88,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -125,7 +125,7 @@ msgstr "Tipka isključivanja:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Isključi zaslon kada je neaktivan:"
 
 #: src/Plug.vala:361

--- a/po/ht.po
+++ b/po/ht.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/hu.po
+++ b/po/hu.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Energiagazdálkodás"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr "Akkumulátorról"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr "Bekapcsolás gomb:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/hy.po
+++ b/po/hy.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Էլեկտրասնուցում"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/hz.po
+++ b/po/hz.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ia.po
+++ b/po/ia.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/id.po
+++ b/po/id.po
@@ -37,7 +37,7 @@ msgid "Power"
 msgstr "Daya"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Konfigurasikan kecerahan tampilan, tombol daya, dan perilaku tidur"
 
 #: src/Plug.vala:75
@@ -49,7 +49,7 @@ msgid "On Battery"
 msgstr "Pada daya baterai"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Tombol tidur"
 
 #: src/Plug.vala:144
@@ -85,7 +85,7 @@ msgid "Docked lid close"
 msgstr "Tutup lid dok"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Tidur tidak aktif"
 
 #: src/Plug.vala:166
@@ -124,7 +124,7 @@ msgstr "Tombol power:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Suspen bila tidak aktif untuk:"
 
 #: src/Plug.vala:361

--- a/po/ie.po
+++ b/po/ie.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ig.po
+++ b/po/ig.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ii.po
+++ b/po/ii.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ik.po
+++ b/po/ik.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/io.po
+++ b/po/io.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/is.po
+++ b/po/is.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/it.po
+++ b/po/it.po
@@ -37,7 +37,7 @@ msgid "Power"
 msgstr "Alimentazione"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Configura la luminosità del display, i pulsanti di alimentazione e il "
 "comportamento durante la sospensione"
@@ -51,7 +51,7 @@ msgid "On Battery"
 msgstr "Con batteria"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Pulsante di sospensione"
 
 #: src/Plug.vala:144
@@ -87,7 +87,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Inattività in sospensione"
 
 #: src/Plug.vala:166
@@ -126,7 +126,7 @@ msgstr "Pulsante di accensione:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Sospendere quando inattivo per:"
 
 #: src/Plug.vala:361

--- a/po/iu.po
+++ b/po/iu.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ja.po
+++ b/po/ja.po
@@ -33,7 +33,7 @@ msgid "Power"
 msgstr "電源"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "ディスプレイの明るさ、電源ボタン、スリープ動作を設定します"
 
 #: src/Plug.vala:75
@@ -45,7 +45,7 @@ msgid "On Battery"
 msgstr "バッテリー時"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "スリープボタン"
 
 #: src/Plug.vala:144
@@ -81,7 +81,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -117,7 +117,7 @@ msgid "Power button:"
 msgstr "電源ボタン:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "非アクティブ時にサスペンド:"
 
 #: src/Plug.vala:361

--- a/po/jv.po
+++ b/po/jv.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ka.po
+++ b/po/ka.po
@@ -32,7 +32,7 @@ msgid "Power"
 msgstr "ელექტროენერგია"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -44,7 +44,7 @@ msgid "On Battery"
 msgstr "ბატარეაზე"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -80,7 +80,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -116,7 +116,7 @@ msgid "Power button:"
 msgstr "ენერგიის ღილაკი:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/kg.po
+++ b/po/kg.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ki.po
+++ b/po/ki.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/kj.po
+++ b/po/kj.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/kk.po
+++ b/po/kk.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/kl.po
+++ b/po/kl.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/km.po
+++ b/po/km.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/kn.po
+++ b/po/kn.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ko.po
+++ b/po/ko.po
@@ -38,7 +38,7 @@ msgid "Power"
 msgstr "전력"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "디스플레이 밝기, 전원 버튼, 잠자기 작동 방식 설정하기"
 
 #: src/Plug.vala:75
@@ -50,7 +50,7 @@ msgid "On Battery"
 msgstr "배터리 사용 시"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "잠자기 버튼"
 
 #: src/Plug.vala:144
@@ -86,7 +86,7 @@ msgid "Docked lid close"
 msgstr "고정 덮개 닫기"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "사용하지 않을 땐 잠자기"
 
 #: src/Plug.vala:166
@@ -122,7 +122,7 @@ msgid "Power button:"
 msgstr "전원 버튼:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "다음 시간 동안 활동이 없으면 잠자기:"
 
 #: src/Plug.vala:361

--- a/po/kr.po
+++ b/po/kr.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ks.po
+++ b/po/ks.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ku.po
+++ b/po/ku.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Hêz"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/kv.po
+++ b/po/kv.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/kw.po
+++ b/po/kw.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ky.po
+++ b/po/ky.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/la.po
+++ b/po/la.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/lb.po
+++ b/po/lb.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr "Stroum"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr "Un der Batterie"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/lg.po
+++ b/po/lg.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/li.po
+++ b/po/li.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ln.po
+++ b/po/ln.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/lo.po
+++ b/po/lo.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/lt.po
+++ b/po/lt.po
@@ -33,7 +33,7 @@ msgid "Power"
 msgstr "Maitinimas"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Konfigūruoti ekrano ryškumą, maitinimo mygtukų ir miego elgseną"
 
 #: src/Plug.vala:75
@@ -45,7 +45,7 @@ msgid "On Battery"
 msgstr "Naudojama baterija"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Miego mygtukas"
 
 #: src/Plug.vala:144
@@ -81,7 +81,7 @@ msgid "Docked lid close"
 msgstr "Nešiojamojo kompiuterio dangtis uždarytas"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Miegas esant neveiklumui"
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr "Maitinimo mygtukas:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Pristabdyti, kai kompiuteris neaktyvus:"
 
 #: src/Plug.vala:361

--- a/po/lu.po
+++ b/po/lu.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/lv.po
+++ b/po/lv.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Barošanas pārvaldība"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr "No akumulatora"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr "Izslēgšanas poga:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/mg.po
+++ b/po/mg.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/mh.po
+++ b/po/mh.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/mi.po
+++ b/po/mi.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/mk.po
+++ b/po/mk.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ml.po
+++ b/po/ml.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/mn.po
+++ b/po/mn.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/mo.po
+++ b/po/mo.po
@@ -22,7 +22,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -34,7 +34,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -70,7 +70,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -106,7 +106,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/mr.po
+++ b/po/mr.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ms.po
+++ b/po/ms.po
@@ -36,7 +36,7 @@ msgid "Power"
 msgstr "Kuasa"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Konfigut kecerahan paparan ,butang kuasa, dan kelakuan tidur"
 
 #: src/Plug.vala:75
@@ -48,7 +48,7 @@ msgid "On Battery"
 msgstr "Mod Bateri"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Butang tidur"
 
 #: src/Plug.vala:144
@@ -84,7 +84,7 @@ msgid "Docked lid close"
 msgstr "Penutup terlabuh ditutup"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Tidur tidak aktif"
 
 #: src/Plug.vala:166
@@ -123,7 +123,7 @@ msgstr "Butang kuasa:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Tangguh bila tidak aktif selama:"
 
 #: src/Plug.vala:361

--- a/po/mt.po
+++ b/po/mt.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/my.po
+++ b/po/my.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/na.po
+++ b/po/na.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/nb.po
+++ b/po/nb.po
@@ -38,7 +38,7 @@ msgid "Power"
 msgstr "Strøm"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Konfigurer lysstyrke, strømknapper og strømsparing"
 
 #: src/Plug.vala:75
@@ -50,7 +50,7 @@ msgid "On Battery"
 msgstr "På batteri"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Dvale-knapp"
 
 #: src/Plug.vala:144
@@ -88,7 +88,7 @@ msgstr "Tilkoblet skjermlukking"
 
 #: src/Plug.vala:152
 #, fuzzy
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Dvalgang inaktiv"
 
 #: src/Plug.vala:166
@@ -125,7 +125,7 @@ msgstr "Av/på-knapp"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Hvilemodus ved inaktivitet i:"
 
 #: src/Plug.vala:361

--- a/po/nd.po
+++ b/po/nd.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ne.po
+++ b/po/ne.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ng.po
+++ b/po/ng.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/nl.po
+++ b/po/nl.po
@@ -39,7 +39,7 @@ msgid "Power"
 msgstr "Energie"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "configureren van beeldcherm helderheid, aan/uit knop en slaap gedrag"
 
 #: src/Plug.vala:75
@@ -51,7 +51,7 @@ msgid "On Battery"
 msgstr "Op accustroom"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Slaapstandknop"
 
 #: src/Plug.vala:144
@@ -87,7 +87,7 @@ msgid "Docked lid close"
 msgstr "In standaard gesloten deksel"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Slaapstand inactiviteit"
 
 #: src/Plug.vala:166
@@ -126,7 +126,7 @@ msgstr "Aan-/uit-knop:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Naar slaapstand wanneer inactief voor:"
 
 #: src/Plug.vala:361

--- a/po/nn.po
+++ b/po/nn.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Straum"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -120,7 +120,7 @@ msgstr ""
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Gå i kvilemodus når inaktiv i:"
 
 #: src/Plug.vala:361

--- a/po/no.po
+++ b/po/no.po
@@ -23,7 +23,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -35,7 +35,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -71,7 +71,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -107,7 +107,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/nr.po
+++ b/po/nr.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/nv.po
+++ b/po/nv.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ny.po
+++ b/po/ny.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/oc.po
+++ b/po/oc.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/oj.po
+++ b/po/oj.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/om.po
+++ b/po/om.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/or.po
+++ b/po/or.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/os.po
+++ b/po/os.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/pa.po
+++ b/po/pa.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/pi.po
+++ b/po/pi.po
@@ -22,7 +22,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -34,7 +34,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -70,7 +70,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -106,7 +106,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/pl.po
+++ b/po/pl.po
@@ -38,7 +38,7 @@ msgid "Power"
 msgstr "Zasilanie"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Konfiguruj jasność ekranu, zachowanie przycisków zasilania i trybu usypiania"
 
@@ -51,7 +51,7 @@ msgid "On Battery"
 msgstr "Na baterii"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Przycisk uśpienia"
 
 #: src/Plug.vala:144
@@ -87,7 +87,7 @@ msgid "Docked lid close"
 msgstr "Zamknięcie pokrywy w doku"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Nieaktywność usypiania"
 
 #: src/Plug.vala:166
@@ -124,7 +124,7 @@ msgid "Power button:"
 msgstr "Przycisk zasilania:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Uśpienie, gdy nieaktywność przez:"
 
 #: src/Plug.vala:361

--- a/po/power-plug.pot
+++ b/po/power-plug.pot
@@ -34,7 +34,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -46,7 +46,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -82,7 +82,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -118,7 +118,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ps.po
+++ b/po/ps.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/pt.po
+++ b/po/pt.po
@@ -37,7 +37,7 @@ msgid "Power"
 msgstr "Energia"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Configurar brilho do ecrã, botões de energia e modo de suspensão"
 
 #: src/Plug.vala:75
@@ -49,7 +49,7 @@ msgid "On Battery"
 msgstr "Bateria"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Botão de suspensão"
 
 #: src/Plug.vala:144
@@ -85,7 +85,7 @@ msgid "Docked lid close"
 msgstr "Tampa fechada com Dock"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Suspensão inativa"
 
 #: src/Plug.vala:166
@@ -122,7 +122,7 @@ msgid "Power button:"
 msgstr "Botão ligar/desligar:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Suspender quando inactivo durante:"
 
 #: src/Plug.vala:361

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -36,7 +36,7 @@ msgid "Power"
 msgstr "Energia"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Configurar brilho da tela, botões de energia e comportamento de hibernação"
 
@@ -49,7 +49,7 @@ msgid "On Battery"
 msgstr "Na bateria"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Botão de suspensão"
 
 #: src/Plug.vala:144
@@ -85,7 +85,7 @@ msgid "Docked lid close"
 msgstr "Tampa fechada em um dock"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Suspensão inativa"
 
 #: src/Plug.vala:166
@@ -125,7 +125,7 @@ msgstr "Botão liga/desliga:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Suspender quando inativo por:"
 
 #: src/Plug.vala:361

--- a/po/qu.po
+++ b/po/qu.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/rm.po
+++ b/po/rm.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/rn.po
+++ b/po/rn.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ro.po
+++ b/po/ro.po
@@ -36,7 +36,7 @@ msgid "Power"
 msgstr "Alimentare"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Configurați luminozitatea ecranului, butoanele de putere, și un comportament "
 "de somn"
@@ -50,7 +50,7 @@ msgid "On Battery"
 msgstr "Pe baterie"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Buton somn"
 
 #: src/Plug.vala:144
@@ -86,7 +86,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Mod somn inactiv"
 
 #: src/Plug.vala:166
@@ -124,7 +124,7 @@ msgstr "Butonul de pornire:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Suspendă atunci când este inactiv pentru:"
 
 #: src/Plug.vala:361

--- a/po/ru.po
+++ b/po/ru.po
@@ -38,7 +38,7 @@ msgid "Power"
 msgstr "Питание"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Настройка яркости экрана, сна и кнопок питания"
 
 #: src/Plug.vala:75
@@ -50,7 +50,7 @@ msgid "On Battery"
 msgstr "От батареи"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Кнопка сна"
 
 #: src/Plug.vala:144
@@ -86,7 +86,7 @@ msgid "Docked lid close"
 msgstr "Крышка закрыта"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Сон при простое"
 
 #: src/Plug.vala:166
@@ -122,7 +122,7 @@ msgid "Power button:"
 msgstr "Кнопка питания:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Перейти в ждущий режим через:"
 
 #: src/Plug.vala:361

--- a/po/rue.po
+++ b/po/rue.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/rw.po
+++ b/po/rw.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/sa.po
+++ b/po/sa.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/sc.po
+++ b/po/sc.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/sd.po
+++ b/po/sd.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/se.po
+++ b/po/se.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/sg.po
+++ b/po/sg.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/si.po
+++ b/po/si.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/sk.po
+++ b/po/sk.po
@@ -37,7 +37,7 @@ msgid "Power"
 msgstr "Napájanie"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Nastavenie jasu monitora, tlačidla napájania a správania sa v režime spánku"
 
@@ -50,7 +50,7 @@ msgid "On Battery"
 msgstr "Na batérii"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Tlačidlo uspania"
 
 #: src/Plug.vala:144
@@ -86,7 +86,7 @@ msgid "Docked lid close"
 msgstr "Zavreté veko v doku"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Neaktívne uspanie"
 
 #: src/Plug.vala:166
@@ -123,7 +123,7 @@ msgstr "Tlačidlo napájania:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Odložiť ak neaktívny počas:"
 
 #: src/Plug.vala:361

--- a/po/sl.po
+++ b/po/sl.po
@@ -39,7 +39,7 @@ msgid "Power"
 msgstr "Napajanje"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Nastavitve svetlosti, gumbov za napajanje in spanja"
 
 #: src/Plug.vala:75
@@ -51,7 +51,7 @@ msgid "On Battery"
 msgstr "Na bateriji"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Gumb za spanje"
 
 #: src/Plug.vala:144
@@ -87,7 +87,7 @@ msgid "Docked lid close"
 msgstr "Zaprje pokrova na postaji"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Spanje neaktivno"
 
 #: src/Plug.vala:166
@@ -123,7 +123,7 @@ msgid "Power button:"
 msgstr "Ob pritisku gumba za vklop:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Ob nedejavnosti v spanje po:"
 
 #: src/Plug.vala:361

--- a/po/sm.po
+++ b/po/sm.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/sma.po
+++ b/po/sma.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Energie"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/sn.po
+++ b/po/sn.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/so.po
+++ b/po/so.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/sq.po
+++ b/po/sq.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr "Furnizimi i energjisë"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Konfiguro ndriçimin e ekranit, butonat e energjisë dhe sjelljen e pezullimit"
 
@@ -43,7 +43,7 @@ msgid "On Battery"
 msgstr "Me bateri"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -79,7 +79,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -116,7 +116,7 @@ msgstr "Butoni i ndezjes:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Fik ekranin kur të jetë joaktiv për:"
 
 #: src/Plug.vala:361

--- a/po/sr.po
+++ b/po/sr.po
@@ -36,7 +36,7 @@ msgid "Power"
 msgstr "Напајање"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Подесите осветљеност екрана, дугмад напајања и понашање спавања"
 
 #: src/Plug.vala:75
@@ -48,7 +48,7 @@ msgid "On Battery"
 msgstr "На батерији"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Дугме спавања"
 
 #: src/Plug.vala:144
@@ -84,7 +84,7 @@ msgid "Docked lid close"
 msgstr "Затвори прикачени поклопац"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "Спавање није радно"
 
 #: src/Plug.vala:166
@@ -121,7 +121,7 @@ msgstr "Дугме напајања:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Обустави када је нерадан након:"
 
 #: src/Plug.vala:361

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -52,7 +52,7 @@ msgid "Power"
 msgstr "Snaga"
 
 #: ../src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: ../src/Plug.vala:75
@@ -64,7 +64,7 @@ msgid "On Battery"
 msgstr ""
 
 #: ../src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: ../src/Plug.vala:144
@@ -100,7 +100,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: ../src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: ../src/Plug.vala:166
@@ -136,7 +136,7 @@ msgid "Power button:"
 msgstr "Дугме за укључивање:"
 
 #: ../src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: ../src/Plug.vala:361

--- a/po/ss.po
+++ b/po/ss.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/st.po
+++ b/po/st.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/su.po
+++ b/po/su.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/sv.po
+++ b/po/sv.po
@@ -36,7 +36,7 @@ msgid "Power"
 msgstr "Ström"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Ställ in skärmens ljusstyrka, strömbrytare och strömspararlägen"
 
 #: src/Plug.vala:75
@@ -48,7 +48,7 @@ msgid "On Battery"
 msgstr "På batteri"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -84,7 +84,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -121,7 +121,7 @@ msgstr "Avstängningsknapp:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Stäng av skärm vid inaktivitet i:"
 
 #: src/Plug.vala:361

--- a/po/sw.po
+++ b/po/sw.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ta.po
+++ b/po/ta.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "திறன்"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr "பவர் பொத்தான்:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/te.po
+++ b/po/te.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/tg.po
+++ b/po/tg.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/th.po
+++ b/po/th.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "พลังงาน"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "ตั้งค่าความสว่างในการแสดงผล ปุ่มเปิด/ปิด และโหมดสลีป"
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr "เมื่อใช้ไฟจากแบตเตอรี่"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr "ปุ่มปิดเครื่อง:"
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ti.po
+++ b/po/ti.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/tk.po
+++ b/po/tk.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/tl.po
+++ b/po/tl.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/tn.po
+++ b/po/tn.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/to.po
+++ b/po/to.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/tr.po
+++ b/po/tr.po
@@ -36,7 +36,7 @@ msgid "Power"
 msgstr "Güç"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "Ekran parlaklığı, güç düğmeleri ve uyku davranışını ayarla"
 
 #: src/Plug.vala:75
@@ -48,7 +48,7 @@ msgid "On Battery"
 msgstr "Pilde"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "Uyku düğmesi"
 
 #: src/Plug.vala:144
@@ -84,7 +84,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -124,7 +124,7 @@ msgstr "Güç tuşu:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Şu kadar süre etkin değilse askıya al:"
 
 #: src/Plug.vala:361

--- a/po/ts.po
+++ b/po/ts.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/tt.po
+++ b/po/tt.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/tw.po
+++ b/po/tw.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ty.po
+++ b/po/ty.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ug.po
+++ b/po/ug.po
@@ -36,7 +36,7 @@ msgid "Power"
 msgstr "توك مەنبەسى"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "ئىكران يورۇقلۇقىنى، توك مەنبەسى كۇنۇپكىسىنى ۋە ئۇخلىتىش شەكلىنى تەڭشەش"
 
 #: src/Plug.vala:75
@@ -48,7 +48,7 @@ msgid "On Battery"
 msgstr "باتارىيەنى ئىشلىتىۋاتىدۇ"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "ئۇخلىتىش كۇنۇپكىسى"
 
 #: src/Plug.vala:144
@@ -84,7 +84,7 @@ msgid "Docked lid close"
 msgstr "Docked ستونىنى تاقاش"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "ئۇخلاش ھالىتىگە كىردى"
 
 #: src/Plug.vala:166
@@ -121,7 +121,7 @@ msgstr "توك مەنبەسى كۇنۇپكىسى"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "مەشغۇلات قىلمىغان ۋاقىتتا كومپىيۇتىرنى توڭلىتىش"
 
 #: src/Plug.vala:361

--- a/po/uk.po
+++ b/po/uk.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Живлення"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 "Налаштування яскравості дисплея, кнопок живлення та поведінки переходу у "
 "режим сну"
@@ -49,7 +49,7 @@ msgid "On Battery"
 msgstr "Робота на акумуляторах"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -85,7 +85,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -122,7 +122,7 @@ msgstr "Кнопка живлення:"
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "Вимкнення дисплея при неактивності для:"
 
 #: src/Plug.vala:361

--- a/po/ur.po
+++ b/po/ur.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/uz.po
+++ b/po/uz.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/ve.po
+++ b/po/ve.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/vi.po
+++ b/po/vi.po
@@ -35,7 +35,7 @@ msgid "Power"
 msgstr "Năng lượng"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -47,7 +47,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -83,7 +83,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -119,7 +119,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/vo.po
+++ b/po/vo.po
@@ -22,7 +22,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -34,7 +34,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -70,7 +70,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -106,7 +106,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/wa.po
+++ b/po/wa.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/wo.po
+++ b/po/wo.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/xh.po
+++ b/po/xh.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/yi.po
+++ b/po/yi.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/yo.po
+++ b/po/yo.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/za.po
+++ b/po/za.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/zh.po
+++ b/po/zh.po
@@ -22,7 +22,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -34,7 +34,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -70,7 +70,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -106,7 +106,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -38,7 +38,7 @@ msgid "Power"
 msgstr "电源"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "配置显示器亮度、电源按键和睡眠方式"
 
 #: src/Plug.vala:75
@@ -50,7 +50,7 @@ msgid "On Battery"
 msgstr "使用电池"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "睡眠键"
 
 #: src/Plug.vala:144
@@ -86,7 +86,7 @@ msgid "Docked lid close"
 msgstr "盖子关闭"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "闲时睡眠"
 
 #: src/Plug.vala:166
@@ -123,7 +123,7 @@ msgstr "电源按钮："
 
 #: src/Plug.vala:342
 #, fuzzy
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "闲时挂起："
 
 #: src/Plug.vala:361

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -38,7 +38,7 @@ msgid "Power"
 msgstr "電源"
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr "調整顯示器亮度、電源按鈕和睡眠行為"
 
 #: src/Plug.vala:75
@@ -50,7 +50,7 @@ msgid "On Battery"
 msgstr "使用電池"
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr "睡眠按鈕"
 
 #: src/Plug.vala:144
@@ -86,7 +86,7 @@ msgid "Docked lid close"
 msgstr "臺座上蓋關閉"
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr "睡眠停用"
 
 #: src/Plug.vala:166
@@ -122,7 +122,7 @@ msgid "Power button:"
 msgstr "電源按鈕："
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr "電腦睡眠前的不使用時間："
 
 #: src/Plug.vala:361

--- a/po/zu.po
+++ b/po/zu.po
@@ -30,7 +30,7 @@ msgid "Power"
 msgstr ""
 
 #: src/Plug.vala:56
-msgid "Configure display brightness, power buttons, and sleep behavior"
+msgid "Configure display brightness, power buttons, and suspend behavior"
 msgstr ""
 
 #: src/Plug.vala:75
@@ -42,7 +42,7 @@ msgid "On Battery"
 msgstr ""
 
 #: src/Plug.vala:143
-msgid "Sleep button"
+msgid "Suspend button"
 msgstr ""
 
 #: src/Plug.vala:144
@@ -78,7 +78,7 @@ msgid "Docked lid close"
 msgstr ""
 
 #: src/Plug.vala:152
-msgid "Sleep inactive"
+msgid "Suspend inactive"
 msgstr ""
 
 #: src/Plug.vala:166
@@ -114,7 +114,7 @@ msgid "Power button:"
 msgstr ""
 
 #: src/Plug.vala:342
-msgid "Sleep when inactive for:"
+msgid "Suspend when inactive for:"
 msgstr ""
 
 #: src/Plug.vala:361


### PR DESCRIPTION
Settle on using "suspend" instead of "sleep", fixes #52 