### PR TITLE
Also set sleep-inactive action type enums

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -30,6 +30,16 @@ public class Power.MainView : Gtk.Grid {
     private PowerSettings screen;
     private PowerSupply power_supply;
 
+    private enum PowerActionType {
+        BLANK,
+        SUSPEND,
+        SHUTDOWN,
+        HIBERNATE,
+        INTERACTIVE,
+        NOTHING,
+        LOGOUT
+    }
+
     construct {
         orientation = Gtk.Orientation.VERTICAL;
         margin_bottom = 12;
@@ -162,6 +172,9 @@ public class Power.MainView : Gtk.Grid {
         sleep_timeout_label.xalign = 1;
 
         var sleep_timeout = new TimeoutComboBox (settings, "sleep-inactive-ac-timeout");
+        sleep_timeout.enum_property = "sleep-inactive-ac-type";
+        sleep_timeout.enum_never_value = PowerActionType.NOTHING;
+        sleep_timeout.enum_normal_value = PowerActionType.SUSPEND;
 
         var ac_grid = new Gtk.Grid ();
         ac_grid.column_spacing = 12;
@@ -182,6 +195,9 @@ public class Power.MainView : Gtk.Grid {
             label_size.add_widget (battery_timeout_label);
 
             var battery_timeout = new TimeoutComboBox (settings, "sleep-inactive-battery-timeout");
+            battery_timeout.enum_property = "sleep-inactive-battery-type";
+            battery_timeout.enum_never_value = PowerActionType.NOTHING;
+            battery_timeout.enum_normal_value = PowerActionType.SUSPEND;
 
             var battery_grid = new Gtk.Grid ();
             battery_grid.column_spacing = 12;

--- a/src/Widgets/TimeoutComboBox.vala
+++ b/src/Widgets/TimeoutComboBox.vala
@@ -20,6 +20,45 @@
 namespace Power {
     class TimeoutComboBox : Gtk.ComboBoxText {
 
+        private string? _enum_property = null;
+        public string? enum_property {
+            get {
+                return _enum_property;
+            }
+            set {
+                if (value != _enum_property) {
+                    _enum_property = value;
+                    update_combo ();
+                }
+            }
+        }
+
+        private int _enum_never_value = -1;
+        public int enum_never_value {
+            get {
+                return _enum_never_value;
+            }
+            set {
+                if (value != _enum_never_value) {
+                    _enum_never_value = value;
+                    update_combo ();
+                }
+            }
+        }
+
+        private int _enum_normal_value = -1;
+        public int enum_normal_value {
+            get {
+                return _enum_normal_value;
+            }
+            set {
+                if (value != _enum_normal_value) {
+                    _enum_normal_value = value;
+                    update_combo ();
+                }
+            }
+        }
+
         private GLib.Settings schema;
         private string key;
 
@@ -57,6 +96,14 @@ namespace Power {
         }
 
         private void update_settings () {
+            if (enum_property != null && enum_never_value != -1 && enum_normal_value != -1) {
+                if (active == 0) {
+                    schema.set_enum (enum_property, enum_never_value);
+                } else {
+                    schema.set_enum (enum_property, enum_normal_value);
+                }
+            }
+
             schema.set_int (key, timeout[active]);
         }
 
@@ -76,6 +123,14 @@ namespace Power {
 
         private void update_combo () {
             int val = schema.get_int (key);
+
+            if (enum_property != null && enum_never_value != -1 && enum_normal_value != -1) {
+                var enum_value = schema.get_enum (enum_property);
+                if (enum_value == enum_never_value) {
+                    active = 0;
+                    return;
+                }
+            }
 
             // need to process value to comply our timeout level
             active = find_closest (val);


### PR DESCRIPTION
I think this fixes #89 from my limited testing.

It would seem that despite the GSD schema saying that 0 means never, you also have to set the "do nothing" option on the relevant key too.