### PR TITLE
fix excutable name io.elementary.dpms-helper

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -317,7 +317,7 @@ public class Power.MainView : Gtk.Grid {
 
     private static void run_dpms_helper () {
         try {
-            string[] argv = { "elementary-dpms-helper" };
+            string[] argv = { "io.elementary.dpms-helper" };
             Process.spawn_async (null, argv, Environ.get (),
                 SpawnFlags.SEARCH_PATH | SpawnFlags.STDERR_TO_DEV_NULL | SpawnFlags.STDOUT_TO_DEV_NULL,
                 null, null);


### PR DESCRIPTION
** (io.elementary.switchboard:15400): WARNING **: 06:32:06.098: MainView.vala:325: Failed to reset dpms settings: Failed to execute child process “elementary-dpms-helper” (No such file or directory)