### PR TITLE
build: use define_variable with pkgconfig paths 

### DIFF
--- a/cli/meson.build
+++ b/cli/meson.build
@@ -1,5 +1,5 @@
 helper_name = 'io.elementary.logind.helper'
-helper_dir = join_paths(get_option('prefix'), get_option('libexecdir'))
+helper_dir = libexecdir
 
 config_data = configuration_data()
 config_data.set('LIBEXEC', helper_dir)

--- a/cli/meson.build
+++ b/cli/meson.build
@@ -9,7 +9,7 @@ configure_file(
     input: 'io.elementary.logind.helper.service.in',
     output: '@BASENAME@',
     configuration: config_data,
-    install_dir: dbus_dep.get_pkgconfig_variable('system_bus_services_dir')
+    install_dir: dbus_dep.get_pkgconfig_variable('system_bus_services_dir', define_variable: ['datadir', datadir])
 )
 
 install_data(

--- a/cli/meson.build
+++ b/cli/meson.build
@@ -14,7 +14,7 @@ configure_file(
 
 install_data(
     'io.elementary.logind.helper.conf',
-    install_dir: join_paths(dbus_dep.get_pkgconfig_variable('sysconfdir'), 'dbus-1', 'system.d')
+    install_dir: join_paths(datadir, 'dbus-1', 'system.d')
 )
 
 executable(

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,6 +1,6 @@
 config_data = configuration_data()
 config_data.set('GETTEXT_PACKAGE', gettext_name)
-config_data.set('PKGDATADIR', join_paths(get_option('prefix'), get_option('datadir')))
+config_data.set('PKGDATADIR', datadir)
 
 configure_file(
     input: 'io.elementary.switchboard.power.policy.in',
@@ -15,5 +15,5 @@ i18n.merge_file(
     po_dir: join_paths(meson.source_root(), 'po', 'extra'),
     type: 'xml',
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'metainfo'),
+    install_dir: join_paths(datadir, 'metainfo'),
 )

--- a/data/meson.build
+++ b/data/meson.build
@@ -6,7 +6,7 @@ configure_file(
     input: 'io.elementary.switchboard.power.policy.in',
     output: '@BASENAME@',
     configuration: config_data,
-    install_dir: polkit_dep.get_pkgconfig_variable('policydir')
+    install_dir: polkit_dep.get_pkgconfig_variable('policydir', define_variable: ['prefix', prefix])
 )
 
 i18n.merge_file(

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,11 @@ gettext_name = meson.project_name() + '-plug'
 gnome = import('gnome')
 i18n = import('i18n')
 
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+libdir = join_paths(prefix, get_option('libdir'))
+libexecdir = join_paths(prefix, get_option('libexecdir'))
+
 add_project_arguments(
     '-DGETTEXT_PACKAGE="@0@"'.format(gettext_name),
     language:'c'

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,6 +13,7 @@ plug_files = files(
 )
 
 switchboard_dep = dependency('switchboard-2.0')
+switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
 
 shared_module(
     meson.project_name(),
@@ -29,5 +30,5 @@ shared_module(
         switchboard_dep
     ],
     install: true,
-    install_dir : join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'hardware')
+    install_dir : join_paths(switchboard_plugsdir, 'hardware')
 )


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this get_pkgconfig_variable will return a
path from within the package's prefix and we cannot write to it.
By using define_variable we can replace the respective directory
to be from the paths from meson. This should have no affect
on elementaryOS.

---
With https://github.com/elementary/switchboard-plug-power/commit/b79b1a063ac4e47d9d8bb277eeb65818333e592f fixed installing to what I believe is a deprecated dbus directory (at least for that purpose).