### PR TITLE
Namespace AccountsService interfaces

### DIFF
--- a/src/GreeterAccountsServicePlugin.vala
+++ b/src/GreeterAccountsServicePlugin.vala
@@ -1,5 +1,5 @@
 [DBus (name = "io.elementary.pantheon.AccountsService")]
-interface Greeter.AccountsService : Object {
+interface Power.Greeter.AccountsService : Object {
     [DBus (name = "SleepInactiveACTimeout")]
     public abstract int sleep_inactive_ac_timeout { get; set; }
     [DBus (name = "SleepInactiveACType")]
@@ -10,6 +10,6 @@ interface Greeter.AccountsService : Object {
 }
 
 [DBus (name = "org.freedesktop.Accounts")]
-interface FDO.Accounts : Object {
+interface Power.FDO.Accounts : Object {
     public abstract string find_user_by_name (string username) throws GLib.Error;
 }


### PR DESCRIPTION
Fixes #150 

Add these interfaces to the namespace used by the rest of the plug so they can't conflict with any future uses of AccountsService within Switchboard.