### PR TITLE
Use correct screen timeout key

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -25,7 +25,6 @@ public class Power.MainView : Gtk.Grid {
     private const string SETTINGS_DAEMON_NAME = "org.gnome.SettingsDaemon.Power";
     private const string SETTINGS_DAEMON_PATH = "/org/gnome/SettingsDaemon/Power";
 
-    private GLib.Settings elementary_dpms_settings;
     private Gtk.Scale scale;
     private PowerSettings screen;
     private PowerSupply power_supply;
@@ -47,7 +46,6 @@ public class Power.MainView : Gtk.Grid {
         var label_size = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
 
         settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.power");
-        elementary_dpms_settings = new GLib.Settings ("io.elementary.dpms");
 
         battery = new Battery ();
         power_supply = new PowerSupply ();
@@ -154,8 +152,7 @@ public class Power.MainView : Gtk.Grid {
         screen_timeout_label.halign = Gtk.Align.END;
         screen_timeout_label.xalign = 1;
 
-        var screen_timeout = new TimeoutComboBox (elementary_dpms_settings, "standby-time");
-        screen_timeout.changed.connect (run_dpms_helper);
+        var screen_timeout = new TimeoutComboBox (new GLib.Settings ("org.gnome.desktop.session"), "idle-delay");
 
         var power_label = new Gtk.Label (_("Power button:"));
         power_label.halign = Gtk.Align.END;
@@ -312,17 +309,6 @@ public class Power.MainView : Gtk.Grid {
             scale.value_changed.disconnect (on_scale_value_changed);
             scale.set_value (val);
             scale.value_changed.connect (on_scale_value_changed);
-        }
-    }
-
-    private static void run_dpms_helper () {
-        try {
-            string[] argv = { "io.elementary.dpms-helper" };
-            Process.spawn_async (null, argv, Environ.get (),
-                SpawnFlags.SEARCH_PATH | SpawnFlags.STDERR_TO_DEV_NULL | SpawnFlags.STDOUT_TO_DEV_NULL,
-                null, null);
-        } catch (SpawnError e) {
-            warning ("Failed to reset dpms settings: %s", e.message);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/elementary/gala/issues/903

The new screen locker is behaving as expected, I'd just forgotten to update the power plug to set the key that controls its screen timeout :sweat_smile: 

While I was here, I had to add support for both `uint` and `int` keys to the `TimeoutComboBox` class, so I made it a bit more GObject style and cleaned up places where we were potentially getting into signal loops by still listening to a signal while changing the underlying value.

I'm reasonably certain we can throw all the DPMS helper stuff away. There's a level of DPMS management that g-s-d can do for us in conjunction with the new screen locker. So I'd be interested to see how it goes without our DPMS helper.