### PR TITLE
Revert "Allow changing lid settings without restarting the system"

### DIFF
--- a/cli/main.vala
+++ b/cli/main.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2020 elementary, Inc. (https://elementary.io)
+ * Copyright (c) 2011-2015 elementary Developers (https://launchpad.net/elementary)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public
@@ -16,11 +16,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  */
-
-[DBus (name = "org.freedesktop.systemd1.Manager")]
-interface SystemDBus : Object {
-    public abstract GLib.ObjectPath reload_or_try_restart_unit (string unit, string mode) throws GLib.Error;
-}
 
 public class LoginDHelper.Application : GLib.Application {
     private const uint ACTIVE_TIMEOUT_SECONDS = 5;
@@ -72,14 +67,6 @@ public class LoginDHelper.Application : GLib.Application {
     public override void shutdown () {
         if (own_id != -1) {
             Bus.unown_name (own_id);
-        }
-
-        /* We need to restart systemd-logind to ensure that the lid settings are taken into account */
-        try {
-            var systemd_bus_proxy = Bus.get_proxy_sync<SystemDBus> (BusType.SYSTEM, "org.freedesktop.systemd1", "/org/freedesktop/systemd1");
-            systemd_bus_proxy.reload_or_try_restart_unit ("systemd-logind.service", "fail");
-        } catch (Error e) {
-            warning (e.message);
         }
 
         base.shutdown ();

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -262,6 +262,22 @@ public class Power.MainView : Gtk.Grid {
 
         main_grid.attach (stack, 0, 8, 2);
 
+        var infobar_label = new Gtk.Label (_("Some changes will not take effect until you restart this computer"));
+
+        var infobar = new Gtk.InfoBar ();
+        infobar.message_type = Gtk.MessageType.WARNING;
+        infobar.revealed = false;
+        infobar.get_content_area ().add (infobar_label);
+
+        var helper = LogindHelper.get_logind_helper ();
+        if (helper != null) {
+            helper.changed.connect (() => {
+                infobar.revealed = true;
+            });
+        }
+
+        add (infobar);
+
         add (main_grid);
         show_all ();
 


### PR DESCRIPTION
Reverts elementary/switchboard-plug-power#119

Restarting systemd-logind in the middle of a session is an absolute must not. It completely ruins the session and this is probably one of the causes of the blank screen after unlock thing.

