### PR TITLE
MainView: show auto power save in battery section

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -315,7 +315,7 @@ public class Power.MainView : Switchboard.SettingsPage {
         label_size.add_widget (power_label);
 
         // hide stack switcher if we only have ac line
-        // stack_switcher.visible = stack.observe_children ().get_n_items () > 1;
+        stack_switcher.visible = stack.observe_children ().get_n_items () > 1;
     }
 
     public static Polkit.Permission? get_permission () {

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -143,21 +143,6 @@ public class Power.MainView : Switchboard.SettingsPage {
             label_size.add_widget (als_label);
         }
 
-        if (power_manager.has_battery ()) {
-            var auto_low_power_label = new Gtk.Label (_("Enable power save on low battery:")) {
-                halign = Gtk.Align.END,
-                xalign = 1
-            };
-
-            var auto_low_power_switch = new Gtk.Switch () {
-                halign = Gtk.Align.START
-            };
-            settings.bind ("power-saver-profile-on-low-battery", auto_low_power_switch, "active", SettingsBindFlags.DEFAULT);
-
-            main_grid.attach (auto_low_power_label, 0, 3);
-            main_grid.attach (auto_low_power_switch, 1, 3);
-        }
-
         if (power_manager.has_lid ()) {
             var lid_closed_label = new Gtk.Label (_("When lid is closed:")) {
                 halign = Gtk.Align.END,
@@ -264,6 +249,20 @@ public class Power.MainView : Switchboard.SettingsPage {
                 battery_grid.attach (battery_power_mode_button, 0, 1, 2);
             }
 
+            var auto_low_power_switch = new Gtk.Switch () {
+                halign = END,
+                valign = CENTER
+            };
+            settings.bind ("power-saver-profile-on-low-battery", auto_low_power_switch, "active", DEFAULT);
+
+            var auto_low_power_label = new Granite.HeaderLabel (_("Automatically Save Power")) {
+                mnemonic_widget = auto_low_power_switch,
+                secondary_text = _("Power Saver mode will be used when battery is low")
+            };
+
+            battery_grid.attach (auto_low_power_label, 0, 3);
+            battery_grid.attach (auto_low_power_switch, 1, 3);
+
             stack.add_titled (battery_grid, "battery", _("On Battery"));
 
             var left_sep = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
@@ -316,7 +315,7 @@ public class Power.MainView : Switchboard.SettingsPage {
         label_size.add_widget (power_label);
 
         // hide stack switcher if we only have ac line
-        stack_switcher.visible = stack.observe_children ().get_n_items () > 1;
+        // stack_switcher.visible = stack.observe_children ().get_n_items () > 1;
     }
 
     public static Polkit.Permission? get_permission () {

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -76,6 +76,7 @@ namespace Power {
             search_results.set ("%s → %s".printf (display_name, _("Lid close")), "");
             search_results.set ("%s → %s".printf (display_name, _("Display brightness")), "");
             search_results.set ("%s → %s".printf (display_name, _("Automatic brightness adjustment")), "");
+            search_results.set ("%s → %s".printf (display_name, _("Automatically Save Power")), "");
             search_results.set ("%s → %s".printf (display_name, _("Inactive display off")), "");
             search_results.set ("%s → %s".printf (display_name, _("Docked lid close")), "");
             search_results.set ("%s → %s".printf (display_name, _("Sleep inactivity timeout")), "");


### PR DESCRIPTION
I think eventually I'd like to move away from this stack switcher design, but at least this groups this battery related feature. While we're here, set mnemonic widget and add this feature to search results

![Screenshot from 2024-02-09 09 22 26](https://github.com/elementary/switchboard-plug-power/assets/7277719/719aef60-2aa5-46b2-8cc9-52350b1479bf)
