### PR TITLE
MainView: justify layout, space between sections

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -72,23 +72,24 @@ public class Power.MainView : Switchboard.SettingsPage {
             warning ("Failed to get settings daemon for brightness setting");
         }
 
-        var main_grid = new Gtk.Grid () {
-            column_spacing = 12,
-            row_spacing = 12
-        };
+        var box = new Gtk.Box (VERTICAL, 24);
+
+        if (power_manager.has_battery ()) {
+            var battery_box = new BatteryBox () {
+                margin_bottom = 12
+            };
+
+            box.append (battery_box);
+        }
 
         if (backlight_detect ()) {
-            var brightness_label = new Gtk.Label (_("Display brightness:")) {
-                halign = Gtk.Align.END,
-                xalign = 1
-            };
-
-            var als_label = new Gtk.Label (_("Automatically adjust brightness:")) {
-                xalign = 1
-            };
-
             var als_switch = new Gtk.Switch () {
-                halign = Gtk.Align.START
+                halign = END
+            };
+
+            var als_label = new Gtk.Label (_("Automatically Adjust Brightness")) {
+                mnemonic_widget = als_switch,
+                xalign = 0
             };
 
             settings.bind ("ambient-enabled", als_switch, "active", SettingsBindFlags.DEFAULT);
@@ -118,45 +119,82 @@ public class Power.MainView : Switchboard.SettingsPage {
             scale.value_changed.connect (on_scale_value_changed);
             ((DBusProxy)screen).g_properties_changed.connect (on_screen_properties_changed);
 
-            main_grid.attach (brightness_label, 0, 1);
-            main_grid.attach (scale, 1, 1);
-            main_grid.attach (als_label, 0, 2);
-            main_grid.attach (als_switch, 1, 2);
+            var brightness_label = new Gtk.Label (_("Display Brightness")) {
+                mnemonic_widget = scale,
+                xalign = 0
+            };
+
+            var brightness_grid = new Gtk.Grid () {
+                column_spacing = 12,
+                row_spacing = 12
+            };
+            brightness_grid.attach (brightness_label, 0, 0);
+            brightness_grid.attach (scale, 1, 0);
+            brightness_grid.attach (als_label, 0, 1);
+            brightness_grid.attach (als_switch, 1, 1);
+
+            box.append (brightness_grid);
 
             label_size.add_widget (brightness_label);
             label_size.add_widget (als_label);
         }
 
         if (power_manager.has_lid ()) {
-            var lid_closed_label = new Gtk.Label (_("When lid is closed:")) {
-                halign = Gtk.Align.END,
-                xalign = 1
+            var infobar_label = new Gtk.Label (_("Some changes will not take effect until you restart this computer"));
+
+            var infobar = new Gtk.InfoBar () {
+                message_type = WARNING,
+                revealed = false
+            };
+            infobar.add_child (infobar_label);
+            infobar.add_css_class (Granite.STYLE_CLASS_FRAME);
+
+            var lid_closed_label = new Gtk.Label (_("Lid Close Behavior")) {
+                xalign = 0
             };
 
-            var lid_closed_box = new LidCloseActionComboBox (false);
-
-            var lid_dock_label = new Gtk.Label (_("When lid is closed with external monitor:")) {
-                halign = Gtk.Align.END,
-                xalign = 1
+            var lid_closed_box = new LidCloseActionComboBox (false) {
+                hexpand = true
             };
 
-            var lid_dock_box = new LidCloseActionComboBox (true);
+            var lid_dock_label = new Gtk.Label (_("Lid Close With External Display")) {
+                xalign = 0
+            };
+
+            var lid_dock_box = new LidCloseActionComboBox (true) {
+                hexpand = true
+            };
 
             label_size.add_widget (lid_closed_label);
             label_size.add_widget (lid_dock_label);
 
-            main_grid.attach (lid_closed_label, 0, 6);
-            main_grid.attach (lid_closed_box, 1, 6);
-            main_grid.attach (lid_dock_label, 0, 7);
-            main_grid.attach (lid_dock_box, 1, 7);
+            var lid_close_grid = new Gtk.Grid () {
+                row_spacing = 12,
+                column_spacing = 12
+            };
+            lid_close_grid.attach (lid_closed_label, 0, 0);
+            lid_close_grid.attach (lid_closed_box, 1, 0);
+            lid_close_grid.attach (lid_dock_label, 0, 1);
+            lid_close_grid.attach (lid_dock_box, 1, 1);
+            lid_close_grid.attach (infobar, 0, 2, 2);
+
+            box.append (lid_close_grid);
+
+            var helper = LogindHelper.get_logind_helper ();
+            if (helper != null) {
+                helper.changed.connect (() => {
+                    infobar.revealed = true;
+                });
+            }
         }
 
-        var screen_timeout_label = new Gtk.Label (_("Turn off display when inactive for:")) {
-            halign = Gtk.Align.END,
-            xalign = 1
+        var screen_timeout_label = new Gtk.Label (_("Automatic Display Off")) {
+            xalign = 0
         };
 
-        var screen_timeout = new TimeoutComboBox (new GLib.Settings ("org.gnome.desktop.session"), "idle-delay");
+        var screen_timeout = new TimeoutComboBox (new GLib.Settings ("org.gnome.desktop.session"), "idle-delay") {
+            hexpand = true
+        };
 
         // FIXME: Virtual machines can only shutdown or do nothing. Tablets always suspend.
         powerbutton_dropdown = new Gtk.DropDown.from_strings ({
@@ -168,24 +206,28 @@ public class Power.MainView : Switchboard.SettingsPage {
         };
 
         var powerbutton_label = new Gtk.Label (_("Power Button Behavior")) {
-            halign = Gtk.Align.END,
-            xalign = 1,
-            mnemonic_widget = powerbutton_dropdown
+            mnemonic_widget = powerbutton_dropdown,
+            xalign = 0
         };
 
+        var main_grid = new Gtk.Grid () {
+            column_spacing = 12,
+            row_spacing = 12
+        };
         main_grid.attach (screen_timeout_label, 0, 4);
         main_grid.attach (screen_timeout, 1, 4);
         main_grid.attach (powerbutton_label, 0, 5);
         main_grid.attach (powerbutton_dropdown, 1, 5);
 
-        var sleep_timeout_label = new Gtk.Label (_("Suspend when inactive for:")) {
-            xalign = 1
+        var sleep_timeout_label = new Gtk.Label (_("Suspend When Inactive For")) {
+            xalign = 0
         };
 
         var sleep_timeout = new TimeoutComboBox (settings, "sleep-inactive-ac-timeout") {
             enum_property = "sleep-inactive-ac-type",
             enum_never_value = PowerActionType.NOTHING,
-            enum_normal_value = PowerActionType.SUSPEND
+            enum_normal_value = PowerActionType.SUSPEND,
+            hexpand = true
         };
 
         var ac_grid = new Gtk.Grid () {
@@ -217,15 +259,16 @@ public class Power.MainView : Switchboard.SettingsPage {
         }
 
         if (power_manager.has_battery ()) {
-            var battery_timeout_label = new Gtk.Label (_("Suspend when inactive for:")) {
-                xalign = 1
+            var battery_timeout_label = new Gtk.Label (_("Suspend When Inactive For")) {
+                xalign = 0
             };
             label_size.add_widget (battery_timeout_label);
 
             var battery_timeout = new TimeoutComboBox (settings, "sleep-inactive-battery-timeout") {
                 enum_property = "sleep-inactive-battery-type",
                 enum_never_value = PowerActionType.NOTHING,
-                enum_normal_value = PowerActionType.SUSPEND
+                enum_normal_value = PowerActionType.SUSPEND,
+                  hexpand = true
             };
 
             var battery_grid = new Gtk.Grid () {
@@ -248,12 +291,16 @@ public class Power.MainView : Switchboard.SettingsPage {
             settings.bind ("power-saver-profile-on-low-battery", auto_low_power_switch, "active", DEFAULT);
 
             var auto_low_power_label = new Granite.HeaderLabel (_("Automatically Save Power")) {
+                hexpand = true,
                 mnemonic_widget = auto_low_power_switch,
                 secondary_text = _("Power Saver mode will be used when battery is low")
             };
 
-            battery_grid.attach (auto_low_power_label, 0, 3);
-            battery_grid.attach (auto_low_power_switch, 1, 3);
+            var auto_low_power_box = new Gtk.Box (HORIZONTAL, 12);
+            auto_low_power_box.append (auto_low_power_label);
+            auto_low_power_box.append (auto_low_power_switch);
+
+            battery_grid.attach (auto_low_power_box, 0, 3, 2);
 
             stack.add_titled (battery_grid, "battery", _("On Battery"));
 
@@ -279,32 +326,6 @@ public class Power.MainView : Switchboard.SettingsPage {
         }
 
         main_grid.attach (stack, 0, 9, 2);
-
-        var infobar_label = new Gtk.Label (_("Some changes will not take effect until you restart this computer"));
-
-        var infobar = new Gtk.InfoBar () {
-            message_type = Gtk.MessageType.WARNING,
-            revealed = false
-        };
-        infobar.add_child (infobar_label);
-        infobar.add_css_class (Granite.STYLE_CLASS_FRAME);
-
-        var helper = LogindHelper.get_logind_helper ();
-        if (helper != null) {
-            helper.changed.connect (() => {
-                infobar.revealed = true;
-            });
-        }
-
-        var box = new Gtk.Box (VERTICAL, 12);
-        box.append (infobar);
-        if (power_manager.has_battery ()) {
-            var battery_box = new BatteryBox () {
-                margin_bottom = 12
-            };
-
-            box.append (battery_box);
-        }
 
         box.append (main_grid);
 

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -69,18 +69,16 @@ namespace Power {
         // 'search' returns results like ("Keyboard → Behavior → Duration", "keyboard<sep>behavior")
         public override async Gee.TreeMap<string, string> search (string search) {
             var search_results = new Gee.TreeMap<string, string> ((GLib.CompareDataFunc<string>)strcmp, (Gee.EqualDataFunc<string>)str_equal);
-            search_results.set ("%s → %s".printf (display_name, _("Suspend button")), "");
-            search_results.set ("%s → %s".printf (display_name, _("Power Button Behavior")), "");
-            search_results.set ("%s → %s".printf (display_name, _("Display inactive")), "");
-            search_results.set ("%s → %s".printf (display_name, _("Dim display")), "");
-            search_results.set ("%s → %s".printf (display_name, _("Lid close")), "");
-            search_results.set ("%s → %s".printf (display_name, _("Display brightness")), "");
-            search_results.set ("%s → %s".printf (display_name, _("Automatic brightness adjustment")), "");
+            search_results.set ("%s → %s".printf (display_name, _("Automatically Adjust Brightness")), "");
             search_results.set ("%s → %s".printf (display_name, _("Automatically Save Power")), "");
-            search_results.set ("%s → %s".printf (display_name, _("Inactive display off")), "");
-            search_results.set ("%s → %s".printf (display_name, _("Docked lid close")), "");
-            search_results.set ("%s → %s".printf (display_name, _("Sleep inactivity timeout")), "");
-            search_results.set ("%s → %s".printf (display_name, _("Suspend inactive")), "");
+            search_results.set ("%s → %s".printf (display_name, _("Automatic Display Off")), "");
+            search_results.set ("%s → %s".printf (display_name, _("Battery Level")), "");
+            search_results.set ("%s → %s".printf (display_name, _("Dim Display")), "");
+            search_results.set ("%s → %s".printf (display_name, _("Display Brightness")), "");
+            search_results.set ("%s → %s".printf (display_name, _("Lid Close Behavior")), "");
+            search_results.set ("%s → %s".printf (display_name, _("Lid Close With External Display")), "");
+            search_results.set ("%s → %s".printf (display_name, _("Power Button Behavior")), "");
+            search_results.set ("%s → %s".printf (display_name, _("Suspend When Inactive For")), "");
             return search_results;
         }
     }

--- a/src/Widgets/LidCloseActionComboBox.vala
+++ b/src/Widgets/LidCloseActionComboBox.vala
@@ -35,10 +35,7 @@ class Power.LidCloseActionComboBox : Gtk.Widget {
     }
 
     construct {
-        combobox = new Gtk.ComboBoxText () {
-            hexpand = true
-        };
-
+        combobox = new Gtk.ComboBoxText ();
         combobox.set_parent (this);
 
         var helper = LogindHelper.get_logind_helper ();

--- a/src/Widgets/TimeoutComboBox.vala
+++ b/src/Widgets/TimeoutComboBox.vala
@@ -93,9 +93,7 @@ class Power.TimeoutComboBox : Gtk.Widget {
     construct {
         key_type = schema.get_value (key).get_type ();
 
-        combobox = new Gtk.ComboBoxText () {
-            hexpand = true
-        };
+        combobox = new Gtk.ComboBoxText ();
         combobox.append_text (_("Never"));
         combobox.append_text (_("5 min"));
         combobox.append_text (_("10 min"));


### PR DESCRIPTION
Try to make this layout a bit less wacky and easier to maintain:
* Put sections in their own grids and double space between sections
* Justify layout of widgets and labels
* Set mnemonic widget where possible (Some comboboxes will need this fixed when ported to dropdown)
* Put infobar by the lid settings

![Screenshot from 2024-02-13 11 34 43@2x](https://github.com/elementary/switchboard-plug-power/assets/7277719/640294cc-ba90-4e92-bbf5-7ba37980ac36)