### PR TITLE
LidCloseActionComboBox: acquire permission async

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -44,8 +44,6 @@ public class Power.MainView : Switchboard.SettingsPage {
         LOGOUT
     }
 
-    private static Polkit.Permission? permission = null;
-
     public MainView () {
         Object (
             title: _("Power"),
@@ -327,22 +325,6 @@ public class Power.MainView : Switchboard.SettingsPage {
                 map[powerbutton_dropdown.selected]
             );
         });
-    }
-
-    public static async Polkit.Permission? get_permission () {
-        if (permission != null) {
-            return permission;
-        }
-
-        try {
-            return yield new Polkit.Permission (
-                "io.elementary.settings.power.administration",
-                new Polkit.UnixProcess (Posix.getpid ())
-            );
-        } catch (Error e) {
-            critical (e.message);
-            return null;
-        }
     }
 
     private static bool backlight_detect () {

--- a/src/Widgets/LidCloseActionComboBox.vala
+++ b/src/Widgets/LidCloseActionComboBox.vala
@@ -69,6 +69,7 @@ class Power.LidCloseActionComboBox : Gtk.Widget {
                 );
             } catch (Error e) {
                 critical (e.message);
+                return false;
             }
         }
 

--- a/src/Widgets/LidCloseActionComboBox.vala
+++ b/src/Widgets/LidCloseActionComboBox.vala
@@ -23,6 +23,8 @@ class Power.LidCloseActionComboBox : Gtk.Widget {
 
     public bool dock { get; construct; }
 
+    private static Polkit.Permission? permission = null;
+
     private Gtk.ComboBoxText combobox;
     private int previous_active;
 
@@ -59,14 +61,20 @@ class Power.LidCloseActionComboBox : Gtk.Widget {
 
     // Returns true on success
     private async bool set_active_with_permission (int index_) {
-        var permission = yield MainView.get_permission ();
         if (permission == null) {
-            return false;
+            try {
+                permission = yield new Polkit.Permission (
+                    "io.elementary.settings.power.administration",
+                    new Polkit.UnixProcess (Posix.getpid ())
+                );
+            } catch (Error e) {
+                critical (e.message);
+            }
         }
 
         if (!permission.allowed) {
             try {
-                permission.acquire ();
+                yield permission.acquire_async ();
             } catch (Error e) {
                 warning (e.message);
                 return false;


### PR DESCRIPTION
Turns out we were still blocking the UI when acquiring permission which caused a "not responding" dialog if you try to interact with the main window